### PR TITLE
Update CHANGELOG with README changes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,3 +12,8 @@ This changelog follows a simplified version of the principles from [Keep a Chang
 - Update README.md to remove topics on version control and add a paragraph about what this repository aims to do
 
 ---
+
+# 2026-05-06
+
+## changed
+- Removed the topics on version control from the README file, as they are now in the working_agreement.md.


### PR DESCRIPTION
Removed version control topics from README as they are now in working_agreement.md.